### PR TITLE
Fix whitelist minting NFT bug.

### DIFF
--- a/src/ERC404.sol
+++ b/src/ERC404.sol
@@ -158,6 +158,15 @@ abstract contract ERC404 is Ownable {
     /// @notice Initialization function to set pairs / etc
     ///         saving gas by avoiding mint / burn on unnecessary targets
     function setWhitelist(address target, bool state) public onlyOwner {
+        // Prevents minting new NFTs by simply toggling the whitelist status. 
+        // This ensures that the capability to mint new tokens cannot be exploited 
+        // by reopen whitelist state.
+        if (state) {
+            uint256[] ownedList = _owned[target];
+            for (uint256 i = 0; i < ownedList.length; i++) {
+                _burn(target);
+            }
+        }
         whitelist[target] = state;
     }
 
@@ -227,6 +236,10 @@ abstract contract ERC404 is Ownable {
                 msg.sender != getApproved[amountOrId]
             ) {
                 revert Unauthorized();
+            }
+
+            if (whitelist[to]) {
+                revert InvalidRecipient();
             }
 
             balanceOf[from] -= _getUnit();


### PR DESCRIPTION
In certain circumstances, exploiting two different states of `transferFrom` can lead to a bug that allows minting ERC-721 tokens out of thin air through a whitelist. Specifically, when a regular EOA (Externally Owned Account) transfers an ERC-721 token to a Whitelist EOA, and then the Whitelist transfers one ERC-20 token back to the regular EOA, due to the `_transfer` method skipping the burn for whitelisted addresses, two ERC-721 tokens are created. To prevent this method from minting tokens, `transferFrom` strictly prohibits transferring the `tokenId` to a whitelisted address. Moreover, to prevent circumventing this restriction by toggling the whitelist status, setting a whitelist address to true will forcibly clear any ERC-721 tokens on the whitelist address.