### PR TITLE
Update project licence

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ The ERC721 implementation here is a bit non-standard, where tokens are instead b
 
 ## Licensing
 
-This source code is unlicensed, and free for anyone to use as they please. Any effort to improve source or explore the concept further is encouraged!
+This source code is MIT, and free for anyone to use as they please. Any effort to improve source or explore the concept further is encouraged!

--- a/src/ERC404.sol
+++ b/src/ERC404.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 abstract contract Ownable {


### PR DESCRIPTION
UNLICENSED is used only for non-open source projects.  README.md mentions that a project is free for anyone to use, so I suggest changing the licence to MIT to make it true open source.
resolves #8.